### PR TITLE
Versión mínima nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/Serabe/ember-bind-helper",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 4.0.0"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Hola Sergio.

En las máquinas que utilizamos para desplegar la app tenemos la versión de node 4.X y no nos dejan actualizarla de momento  :S
Está probado el addon tanto en la 4.X como en la 5.5 y no da problemas.

Un saludo!
